### PR TITLE
v1.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1124,7 +1124,7 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hdr-snipping-tool"
-version = "1.1.1"
+version = "1.1.2"
 dependencies = [
  "anyhow",
  "arboard",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "hdr-snipping-tool"
 # Also update version in src/settings.rs
-version = "1.1.1"
+version = "1.1.2"
 authors = ["Trent Shailer <trent.shailer@gmail.com>"]
 edition = "2021"
 

--- a/src/app/app_core.rs
+++ b/src/app/app_core.rs
@@ -2,7 +2,7 @@ use std::{error::Error, rc::Rc, sync::mpsc::Receiver};
 
 use glium::{
     backend::Facade,
-    glutin::event_loop::EventLoopProxy,
+    glutin::{dpi::LogicalPosition, event_loop::EventLoopProxy},
     texture::RawImage2d,
     uniforms::{MagnifySamplerFilter, MinifySamplerFilter, SamplerBehavior},
     Display, Texture2d,
@@ -20,7 +20,7 @@ pub struct App {
     pub receiver: Receiver<(Image, DisplayInfo)>,
     pub texture_id: Option<TextureId>,
     pub selection_state: SelectionSate,
-    pub selection_start: [f32; 2],
+    pub selection_start: LogicalPosition<f32>,
 }
 
 impl App {
@@ -31,7 +31,7 @@ impl App {
             receiver,
             texture_id: None,
             selection_state: SelectionSate::None,
-            selection_start: [0.0, 0.0],
+            selection_start: LogicalPosition::new(0.0, 0.0),
         }
     }
 
@@ -42,8 +42,8 @@ impl App {
     ) -> Result<(), Box<dyn Error>> {
         let raw = RawImage2d {
             data: std::borrow::Cow::Borrowed(&self.image.current),
-            width: self.image.width,
-            height: self.image.height,
+            width: self.image.size.width,
+            height: self.image.size.height,
             format: glium::texture::ClientFormat::U8U8U8U8,
         };
         let gl_texture = Texture2d::new(gl_ctx, raw)?;
@@ -84,11 +84,13 @@ impl App {
         self.handle_keybinds(ui, display, textures);
 
         // draw image
+        let scale = display.gl_window().window().scale_factor();
+        let image_size = self.image.size.to_logical(scale);
         ui.get_background_draw_list()
             .add_image(
                 self.texture_id.unwrap(),
                 [0.0, 0.0],
-                [self.image.width as f32, self.image.height as f32],
+                [image_size.width, image_size.height],
             )
             .build();
 

--- a/src/app/draw_selection.rs
+++ b/src/app/draw_selection.rs
@@ -1,4 +1,4 @@
-use glium::Display;
+use glium::{glutin::dpi::LogicalSize, Display};
 use imgui::Ui;
 
 use super::App;
@@ -6,23 +6,33 @@ use super::App;
 impl App {
     pub fn draw_selection(&mut self, ui: &mut Ui, display: &Display) {
         // draw border
-        let selection_rect = self.image.get_selection_rect();
+        let selection_rect = self
+            .image
+            .get_selection_rect(display.gl_window().window().scale_factor());
+
+        let top_left = selection_rect[0];
+        let bottom_right = selection_rect[1];
+
         ui.get_background_draw_list()
-            .add_rect(selection_rect[0], selection_rect[1], 0xff_fc_fa_f7)
+            .add_rect(
+                [top_left.x, top_left.y],
+                [bottom_right.x, bottom_right.y],
+                0xff_fc_fa_f7,
+            )
             .thickness(2.0)
             .rounding(1.0)
             .build();
 
         // dim outside of selection
-        let window = display.gl_window().window().inner_size();
+        let window: LogicalSize<f32> = display
+            .gl_window()
+            .window()
+            .inner_size()
+            .to_logical(display.gl_window().window().scale_factor());
 
         // top
         ui.get_background_draw_list()
-            .add_rect(
-                [0.0, 0.0],
-                [window.width as f32, selection_rect[0][1]],
-                0x80_00_00_00,
-            )
+            .add_rect([0.0, 0.0], [window.width, top_left.y], 0x80_00_00_00)
             .filled(true)
             .thickness(0.0)
             .build();
@@ -30,8 +40,8 @@ impl App {
         // left
         ui.get_background_draw_list()
             .add_rect(
-                [0.0, selection_rect[0][1]],
-                [selection_rect[0][0], selection_rect[1][1]],
+                [0.0, top_left.y],
+                [top_left.x, bottom_right.y],
                 0x80_00_00_00,
             )
             .filled(true)
@@ -41,8 +51,8 @@ impl App {
         // bottom
         ui.get_background_draw_list()
             .add_rect(
-                [0.0, selection_rect[1][1]],
-                [window.width as f32, window.height as f32],
+                [0.0, bottom_right.y],
+                [window.width, window.height],
                 0x80_00_00_00,
             )
             .filled(true)
@@ -52,8 +62,8 @@ impl App {
         // right
         ui.get_background_draw_list()
             .add_rect(
-                [selection_rect[1][0], selection_rect[0][1]],
-                [window.width as f32, selection_rect[1][1]],
+                [bottom_right.x, top_left.y],
+                [window.width, bottom_right.y],
                 0x80_00_00_00,
             )
             .filled(true)

--- a/src/app/mouse_guides.rs
+++ b/src/app/mouse_guides.rs
@@ -1,4 +1,4 @@
-use glium::Display;
+use glium::{glutin::dpi::LogicalSize, Display};
 use imgui::Ui;
 
 use super::App;
@@ -6,23 +6,27 @@ use super::App;
 impl App {
     pub fn draw_mouse_guides(&mut self, ui: &mut Ui, display: &Display) {
         let mouse_pos = ui.io().mouse_pos;
-        let window_size = display.gl_window().window().inner_size();
+        let window_size: LogicalSize<f32> = display
+            .gl_window()
+            .window()
+            .inner_size()
+            .to_logical(display.gl_window().window().scale_factor());
 
-        if mouse_pos[1] >= 0.0 && mouse_pos[1] <= window_size.height as f32 {
+        if mouse_pos[1] >= 0.0 && mouse_pos[1] <= window_size.height {
             ui.get_foreground_draw_list()
                 .add_line(
                     [0.0, mouse_pos[1]],
-                    [window_size.width as f32, mouse_pos[1]],
+                    [window_size.width, mouse_pos[1]],
                     0x20_80_80_80,
                 )
                 .build();
         }
 
-        if mouse_pos[0] >= 0.0 && mouse_pos[0] <= window_size.width as f32 {
+        if mouse_pos[0] >= 0.0 && mouse_pos[0] <= window_size.width {
             ui.get_foreground_draw_list()
                 .add_line(
                     [mouse_pos[0], 0.0],
-                    [mouse_pos[0], window_size.height as f32],
+                    [mouse_pos[0], window_size.height],
                     0x20_80_80_80,
                 )
                 .build();

--- a/src/app/selection.rs
+++ b/src/app/selection.rs
@@ -1,4 +1,7 @@
-use glium::Display;
+use glium::{
+    glutin::dpi::{LogicalPosition, LogicalSize},
+    Display,
+};
 use imgui::{Textures, Ui};
 use imgui_glium_renderer::Texture;
 
@@ -23,8 +26,10 @@ impl App {
         pos: [f32; 2],
         size: [f32; 2],
     ) {
-        let mouse_pos = ui.io().mouse_pos;
-        let window_size = display.gl_window().window().inner_size();
+        let mouse_pos = LogicalPosition::new(ui.io().mouse_pos[0], ui.io().mouse_pos[1]);
+        let scale = display.gl_window().window().scale_factor();
+        let window_size: LogicalSize<f32> =
+            display.gl_window().window().inner_size().to_logical(scale);
 
         if ui.is_mouse_released(imgui::MouseButton::Left)
             && self.selection_state != SelectionSate::None
@@ -37,13 +42,13 @@ impl App {
             self.selection_state = SelectionSate::None;
         }
 
-        if !is_inside(mouse_pos, [0.0, 0.0], window_size.into()) {
+        if !is_inside([mouse_pos.x, mouse_pos.y], [0.0, 0.0], window_size.into()) {
             return;
         }
 
         if ui.is_mouse_down(imgui::MouseButton::Left)
             && self.selection_state == SelectionSate::None
-            && !is_inside(mouse_pos, pos, size)
+            && !is_inside([mouse_pos.x, mouse_pos.y], pos, size)
         {
             self.selection_state = SelectionSate::StartedSelecting;
             self.selection_start = mouse_pos;
@@ -55,13 +60,16 @@ impl App {
             self.selection_state = SelectionSate::Selecting;
             let start_pos = self.selection_start;
 
-            let left = f32::min(mouse_pos[0], start_pos[0]);
-            let right = f32::max(mouse_pos[0], start_pos[0]);
-            let top = f32::min(mouse_pos[1], start_pos[1]);
-            let bottom = f32::max(mouse_pos[1], start_pos[1]);
+            let left = f32::min(mouse_pos.x, start_pos.x);
+            let right = f32::max(mouse_pos.x, start_pos.x);
+            let top = f32::min(mouse_pos.y, start_pos.y);
+            let bottom = f32::max(mouse_pos.y, start_pos.y);
 
-            self.image.selection_pos = [left as u32, top as u32];
-            self.image.selection_size = [(right - left) as u32, (bottom - top) as u32];
+            let pos = LogicalPosition::new(left, top);
+            let size = LogicalSize::new(right - left, bottom - top);
+
+            self.image.selection_pos = pos.to_physical(scale);
+            self.image.selection_size = size.to_physical(scale);
         }
     }
 }

--- a/src/capture/display.rs
+++ b/src/capture/display.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use glium::glutin::dpi::{LogicalPosition, LogicalSize};
+use glium::glutin::dpi::{PhysicalPosition, PhysicalSize};
 use windows::Win32::Foundation::{BOOL, LPARAM, POINT, RECT};
 use windows::Win32::Graphics::Gdi::{
     EnumDisplayMonitors, GetMonitorInfoW, HDC, HMONITOR, MONITORINFOEXW,
@@ -79,12 +79,12 @@ impl DisplayInfo {
         })
     }
 
-    pub fn get_position(&self) -> LogicalPosition<i32> {
-        LogicalPosition::new(self.rect.left, self.rect.top)
+    pub fn get_position(&self) -> PhysicalPosition<i32> {
+        PhysicalPosition::new(self.rect.left, self.rect.top)
     }
 
-    pub fn get_size(&self) -> LogicalSize<i32> {
-        LogicalSize::new(
+    pub fn get_size(&self) -> PhysicalSize<i32> {
+        PhysicalSize::new(
             self.rect.right - self.rect.left,
             self.rect.bottom - self.rect.top,
         )

--- a/src/capture/get_capture.rs
+++ b/src/capture/get_capture.rs
@@ -2,6 +2,7 @@ use std::sync::mpsc::channel;
 
 use anyhow::Context;
 use display::DisplayInfo;
+use log::warn;
 use windows::core::{ComInterface, IInspectable};
 use windows::Foundation::TypedEventHandler;
 use windows::Graphics::Capture::{Direct3D11CaptureFramePool, GraphicsCaptureItem};
@@ -141,10 +142,19 @@ pub fn get_capture() -> anyhow::Result<(Image, DisplayInfo)> {
             )
         };
 
-        // TODO find out why capture is returning more data then neccecary
+        let data_width = mapped.RowPitch / 4 / 2;
+        let expected_width = desc.Width;
+
+        if data_width != expected_width {
+            warn!(
+                "data width '{}' does not match expected width '{}'",
+                data_width, expected_width
+            );
+        }
+
         let image: Image = Image::from_u8(
             slice,
-            slice.len() as u32 / desc.Height / 4 / 2, /*  desc.Width as usize */
+            mapped.RowPitch / 4 / 2, /*  desc.Width as usize */
             desc.Height,
         );
 

--- a/src/image/write_image.rs
+++ b/src/image/write_image.rs
@@ -4,23 +4,23 @@ use std::{
 };
 
 use chrono::Local;
+use glium::glutin::dpi::{PhysicalPosition, PhysicalSize};
 use image::{codecs::png::PngEncoder, GenericImageView, ImageBuffer, Rgba};
 
 pub fn save_image(
     image: &[u8],
-    selection_pos: [u32; 2],
-    selection_size: [u32; 2],
-    width: u32,
-    height: u32,
+    selection_pos: PhysicalPosition<u32>,
+    selection_size: PhysicalSize<u32>,
+    size: PhysicalSize<u32>,
 ) -> ImageBuffer<Rgba<u8>, Vec<u8>> {
     let img: ImageBuffer<Rgba<u8>, Vec<u8>> =
-        ImageBuffer::from_raw(width, height, image.to_owned())
+        ImageBuffer::from_raw(size.width, size.height, image.to_owned())
             .unwrap()
             .view(
-                selection_pos[0],
-                selection_pos[1],
-                selection_size[0],
-                selection_size[1],
+                selection_pos.x,
+                selection_pos.y,
+                selection_size.width,
+                selection_size.height,
             )
             .to_image();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use capture::get_capture;
 
 use glium::glutin::event_loop::EventLoopProxy;
 use livesplit_hotkey::{Hook, Hotkey};
-use log::error;
+use log::{error, warn};
 
 use settings::Settings;
 use single_instance::is_first_instance;
@@ -34,6 +34,7 @@ fn run() -> anyhow::Result<()> {
     let first_instance =
         is_first_instance().context("Failed to ensure only one instance is running")?;
     if !first_instance {
+        warn!("Another instance is already running.");
         return Ok(());
     }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -44,7 +44,7 @@ impl Settings {
 
     fn default() -> Self {
         Self {
-            version: String::from("1.1.1"),
+            version: String::from("1.1.2"),
             screenshot_key: KeyCode::PrintScreen,
         }
     }

--- a/src/single_instance.rs
+++ b/src/single_instance.rs
@@ -19,7 +19,7 @@ pub fn is_first_instance() -> anyhow::Result<bool> {
         }
 
         let err = result.err().unwrap();
-        // 0x80070002 is the error code for if no mutex with that names exists, any other error should bd reported
+        // 0x80070002 is the error code for if no mutex with that names exists, any other error should be reported
         if err.code() != HRESULT(0x80070002u32 as i32) {
             return Err(err.into());
         }


### PR DESCRIPTION
fix(#10): Units used now correctly account for if they are physical or logical units to correctly handle display scaling.
Added warning log when another instance is already running and when the expected size of the capture does not match the size of the capture to help address #1 