### PR TITLE
Version 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,7 +1118,7 @@ checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "hdr-snipping-tool"
-version = "1.1.2"
+version = "1.2.0"
 dependencies = [
  "arboard",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 name = "hdr-snipping-tool"
-# Also update version in src/settings.rs
-version = "1.1.2"
+version = "1.2.0"
 authors = ["Trent Shailer <trent.shailer@gmail.com>"]
 edition = "2021"
 

--- a/src/bin/hdr-snipping-tool/app/app_event.rs
+++ b/src/bin/hdr-snipping-tool/app/app_event.rs
@@ -19,6 +19,7 @@ pub enum AppEvent {
     RebuildTexture,
     Save,
     Close,
+    ReloadGui,
 }
 
 impl App {
@@ -52,6 +53,10 @@ impl App {
                 .rebuild_texture(display, renderer)
                 .whatever_context("Failed to rebuild texture")?,
             AppEvent::Tonemap => self.tone_map(),
+            AppEvent::ReloadGui => self
+                .event_proxy
+                .send_event(GuiBackendEvent::ReloadGui)
+                .whatever_context("Failed to send reload event to gui backend")?,
         };
         Ok(())
     }

--- a/src/bin/hdr-snipping-tool/app/keybinds.rs
+++ b/src/bin/hdr-snipping-tool/app/keybinds.rs
@@ -12,5 +12,9 @@ impl App {
             self.event_queue
                 .append(&mut [AppEvent::Save, AppEvent::Close].into());
         }
+
+        if ui.is_key_pressed(imgui::Key::F5) {
+            self.event_queue.push_back(AppEvent::ReloadGui);
+        }
     }
 }

--- a/src/bin/hdr-snipping-tool/app/window_info.rs
+++ b/src/bin/hdr-snipping-tool/app/window_info.rs
@@ -11,10 +11,6 @@ pub struct WindowInfo {
 }
 
 impl WindowInfo {
-    pub fn logical_pos(&self) -> LogicalPosition<f32> {
-        self.pos.to_logical(self.scale)
-    }
-
     pub fn logical_size(&self) -> LogicalSize<f32> {
         self.size.to_logical(self.scale)
     }
@@ -29,7 +25,7 @@ impl WindowInfo {
     /// Get the logical bounds of the window. <br>
     /// returns in order, top, left, bottom, right
     pub fn logical_bounds(&self) -> LogicalBounds {
-        LogicalBounds::from((self.logical_pos(), self.logical_size()))
+        LogicalBounds::from((LogicalPosition::new(0.0, 0.0), self.logical_size()))
     }
 }
 

--- a/src/bin/hdr-snipping-tool/gui_backend.rs
+++ b/src/bin/hdr-snipping-tool/gui_backend.rs
@@ -17,6 +17,7 @@ use tray_icon::{TrayIcon, TrayIconBuilder};
 pub enum GuiBackendEvent {
     ShowWindow,
     HideWindow,
+    ReloadGui,
 }
 
 pub struct GuiBackend<'a> {
@@ -96,7 +97,7 @@ fn init_tray_icon() -> Result<TrayIcon, Whatever> {
         .whatever_context("failed to build icon")?;
 
     let quit_item = MenuItem::with_id(0, "Quit HDR Snipping Tool", true, None);
-    let reload_item = MenuItem::with_id(1, "Reload GUI", true, None);
+    let reload_item = MenuItem::with_id(1, "Reload HDR Snipping Tool", true, None);
 
     let tray_menu =
         Menu::with_items(&[&reload_item, &quit_item]).whatever_context("Failed to build menu")?;
@@ -182,6 +183,13 @@ impl<'a> GuiBackend<'a> {
                         imgui
                             .io_mut()
                             .add_mouse_button_event(imgui::MouseButton::Left, false);
+                    }
+                    GuiBackendEvent::ReloadGui => {
+                        display.gl_window().window().set_visible(false);
+                        imgui
+                            .io_mut()
+                            .add_mouse_button_event(imgui::MouseButton::Left, false);
+                        *control_flow = ControlFlow::ExitWithCode(2)
                     }
                 },
                 Event::WindowEvent {

--- a/src/bin/hdr-snipping-tool/gui_backend.rs
+++ b/src/bin/hdr-snipping-tool/gui_backend.rs
@@ -1,6 +1,7 @@
 use glium::glutin;
 use glium::glutin::event::{Event, WindowEvent};
-use glium::glutin::event_loop::{ControlFlow, EventLoop, EventLoopBuilder};
+use glium::glutin::event_loop::{ControlFlow, EventLoop};
+use glium::glutin::platform::run_return::EventLoopExtRunReturn;
 use glium::glutin::platform::windows::IconExtWindows;
 use glium::glutin::window::{Fullscreen, WindowBuilder};
 use glium::{Display, Surface};
@@ -18,8 +19,8 @@ pub enum GuiBackendEvent {
     HideWindow,
 }
 
-pub struct GuiBackend {
-    pub event_loop: EventLoop<GuiBackendEvent>,
+pub struct GuiBackend<'a> {
+    pub event_loop: &'a mut EventLoop<GuiBackendEvent>,
     pub display: glium::Display,
     pub imgui: Context,
     pub platform: WinitPlatform,
@@ -29,8 +30,7 @@ pub struct GuiBackend {
 }
 
 /// Initialize the app window and tray icon
-pub fn init() -> Result<GuiBackend, Whatever> {
-    let event_loop = EventLoopBuilder::with_user_event().build();
+pub fn init(event_loop: &mut EventLoop<GuiBackendEvent>) -> Result<GuiBackend, Whatever> {
     let context = glutin::ContextBuilder::new().with_vsync(true);
 
     let window_icon =
@@ -43,7 +43,7 @@ pub fn init() -> Result<GuiBackend, Whatever> {
         .with_visible(false)
         .with_window_icon(Some(window_icon));
 
-    let display = Display::new(window_builder, context, &event_loop)
+    let display = Display::new(window_builder, context, event_loop)
         .whatever_context("Failed to initialize display.")?;
 
     let mut imgui = Context::create();
@@ -95,9 +95,11 @@ fn init_tray_icon() -> Result<TrayIcon, Whatever> {
     let icon = tray_icon::Icon::from_resource(1, Some((24, 24)))
         .whatever_context("failed to build icon")?;
 
-    let item = MenuItem::with_id(0, "Quit HDR Snipping Tool", true, None);
+    let quit_item = MenuItem::with_id(0, "Quit HDR Snipping Tool", true, None);
+    let reload_item = MenuItem::with_id(1, "Reload GUI", true, None);
 
-    let tray_menu = Menu::with_items(&[&item]).whatever_context("Failed to build menu")?;
+    let tray_menu =
+        Menu::with_items(&[&reload_item, &quit_item]).whatever_context("Failed to build menu")?;
 
     let tray_icon = TrayIconBuilder::new()
         .with_menu(Box::new(tray_menu))
@@ -109,11 +111,11 @@ fn init_tray_icon() -> Result<TrayIcon, Whatever> {
     Ok(tray_icon)
 }
 
-impl GuiBackend {
+impl<'a> GuiBackend<'a> {
     pub fn main_loop<F: FnMut(&mut bool, &Display, &mut Renderer, &mut Ui) + 'static>(
         self,
         mut run_ui: F,
-    ) {
+    ) -> i32 {
         let GuiBackend {
             event_loop,
             display,
@@ -123,7 +125,7 @@ impl GuiBackend {
             ..
         } = self;
 
-        event_loop.run(move |event, _, control_flow| {
+        let exit_code = event_loop.run_return(|event, _, control_flow| {
             if !display.gl_window().window().is_visible().unwrap() {
                 *control_flow = glutin::event_loop::ControlFlow::Wait;
             } else {
@@ -131,9 +133,11 @@ impl GuiBackend {
             }
 
             if let Ok(tray_event) = MenuEvent::receiver().try_recv() {
-                if tray_event.id == "0" {
-                    *control_flow = ControlFlow::Exit;
-                }
+                match tray_event.id.0.as_str() {
+                    "0" => *control_flow = ControlFlow::ExitWithCode(0),
+                    "1" => *control_flow = ControlFlow::ExitWithCode(1),
+                    _ => {}
+                };
             }
 
             match &event {
@@ -197,7 +201,9 @@ impl GuiBackend {
                     platform.handle_event(imgui.io_mut(), gl_window.window(), &event);
                 }
             }
-        })
+        });
+
+        exit_code
     }
 }
 

--- a/src/bin/hdr-snipping-tool/hotkey.rs
+++ b/src/bin/hdr-snipping-tool/hotkey.rs
@@ -10,7 +10,7 @@ use super::gui_backend::GuiBackendEvent;
 pub fn init_hotkey<C>(
     hotkey: KeyCode,
     capture_provider: Arc<C>,
-    sender: Sender<(HdrCapture, DisplayInfo)>,
+    sender: Arc<Sender<(HdrCapture, DisplayInfo)>>,
     proxy: EventLoopProxy<GuiBackendEvent>,
 ) -> Result<Hook, Whatever>
 where
@@ -19,7 +19,7 @@ where
     let hook = Hook::new().whatever_context("Failed to create hotkey hook")?;
 
     hook.register(Hotkey::from(hotkey), move || {
-        if let Err(e) = handle_capture(capture_provider.as_ref(), &sender, &proxy)
+        if let Err(e) = handle_capture(capture_provider.as_ref(), sender.as_ref(), &proxy)
             .whatever_context::<_, Whatever>("Failed to handle capture")
         {
             log::error!("{}", Report::from_error(e).to_string());
@@ -30,7 +30,7 @@ where
     Ok(hook)
 }
 
-fn handle_capture<C>(
+pub fn handle_capture<C>(
     capture_provider: &C,
     sender: &Sender<(HdrCapture, DisplayInfo)>,
     proxy: &EventLoopProxy<GuiBackendEvent>,

--- a/src/bin/hdr-snipping-tool/settings.rs
+++ b/src/bin/hdr-snipping-tool/settings.rs
@@ -1,64 +1,29 @@
-use std::{fs, io::Read};
+mod load;
+mod pre_1_2_0_settings;
 
 use livesplit_hotkey::KeyCode;
 use serde::{Deserialize, Serialize};
-use snafu::{ResultExt, Whatever};
 
-const SETTINGS_FILE_PATH: &str = "./hdr-config.toml";
+use self::pre_1_2_0_settings::Pre1_2_0Settings;
 
 #[derive(Serialize, Deserialize)]
 pub struct Settings {
-    pub version: String, // Version stored in settings to allow for handling any future breaking changes to existing settings files.
     pub screenshot_key: KeyCode,
 }
 
 impl Settings {
-    pub fn load() -> Result<Self, Whatever> {
-        let file = fs::File::open(SETTINGS_FILE_PATH);
-
-        if file
-            .as_ref()
-            .is_err_and(|e| e.kind() == std::io::ErrorKind::NotFound)
-        {
-            let settings = Self::default();
-            settings
-                .save()
-                .whatever_context("Failed to save settings")?;
-
-            return Ok(settings);
-        }
-
-        let mut file = file.whatever_context("Failed to open settings file.")?;
-        let mut contents = String::new();
-        file.read_to_string(&mut contents)
-            .whatever_context("Failed to read settings file.")?;
-
-        let mut settings: Settings =
-            toml::from_str(&contents).whatever_context("Failed to deserialize settings.")?;
-
-        if settings.version != Self::default().version {
-            settings.version = Self::default().version;
-            settings
-                .save()
-                .whatever_context("Failed to save settings")?;
-        }
-
-        Ok(settings)
-    }
-
     fn default() -> Self {
         Self {
-            version: String::from("1.1.2"),
             screenshot_key: KeyCode::PrintScreen,
         }
     }
+}
 
-    fn save(&self) -> Result<(), Whatever> {
-        let toml_string =
-            toml::to_string_pretty(self).whatever_context("Failed to serialize settings.")?;
-
-        fs::write(SETTINGS_FILE_PATH, toml_string.as_bytes())
-            .whatever_context("Failed to write settings file.")?;
-        Ok(())
+impl From<Pre1_2_0Settings> for Settings {
+    fn from(value: Pre1_2_0Settings) -> Self {
+        Self {
+            screenshot_key: value.screenshot_key,
+            ..Self::default()
+        }
     }
 }

--- a/src/bin/hdr-snipping-tool/settings/load.rs
+++ b/src/bin/hdr-snipping-tool/settings/load.rs
@@ -1,0 +1,58 @@
+use std::{fs, io::Read};
+
+use snafu::{ResultExt, Whatever};
+
+use super::{pre_1_2_0_settings::Pre1_2_0Settings, Settings};
+
+const SETTINGS_FILE_PATH: &str = "./hdr-config.toml";
+
+impl Settings {
+    pub fn migrate(contents: &str) -> Self {
+        if let Ok(pre_1_2_0_settings) = toml::from_str::<Pre1_2_0Settings>(contents) {
+            return Settings::from(pre_1_2_0_settings);
+        }
+
+        Self::default()
+    }
+
+    pub fn load() -> Result<Self, Whatever> {
+        let file = fs::File::open(SETTINGS_FILE_PATH);
+
+        if file
+            .as_ref()
+            .is_err_and(|e| e.kind() == std::io::ErrorKind::NotFound)
+        {
+            let settings = Self::default();
+            settings
+                .save()
+                .whatever_context("Failed to save settings")?;
+
+            return Ok(settings);
+        }
+
+        let mut file = file.whatever_context("Failed to open settings file.")?;
+        let mut contents = String::new();
+        file.read_to_string(&mut contents)
+            .whatever_context("Failed to read settings file.")?;
+
+        let settings: Settings = match toml::from_str(&contents) {
+            Ok(v) => v,
+            Err(_) => Self::migrate(&contents),
+        };
+
+        settings
+            .save()
+            .whatever_context("Failed to save settings")?;
+
+        Ok(settings)
+    }
+
+    fn save(&self) -> Result<(), Whatever> {
+        let toml_string =
+            toml::to_string_pretty(self).whatever_context("Failed to serialize settings.")?;
+
+        fs::write(SETTINGS_FILE_PATH, toml_string.as_bytes())
+            .whatever_context("Failed to write settings file.")?;
+        Ok(())
+    }
+}

--- a/src/bin/hdr-snipping-tool/settings/pre_1_2_0_settings.rs
+++ b/src/bin/hdr-snipping-tool/settings/pre_1_2_0_settings.rs
@@ -1,0 +1,8 @@
+use livesplit_hotkey::KeyCode;
+use serde::Deserialize;
+
+#[derive(Deserialize)]
+pub struct Pre1_2_0Settings {
+    pub version: String,
+    pub screenshot_key: KeyCode,
+}

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -9,7 +9,10 @@ pub struct LogicalBounds {
 
 impl LogicalBounds {
     pub fn contains(&self, point: &LogicalPosition<f32>) -> bool {
-        point.x >= self.left && point.y >= self.top && point.x =< self.right && point.y =< self.bottom;
+        point.x >= self.left
+            && point.y >= self.top
+            && point.x <= self.right
+            && point.y <= self.bottom
     }
 }
 

--- a/src/bounds.rs
+++ b/src/bounds.rs
@@ -9,7 +9,7 @@ pub struct LogicalBounds {
 
 impl LogicalBounds {
     pub fn contains(&self, point: &LogicalPosition<f32>) -> bool {
-        point.x > self.left && point.y > self.top && point.x < self.right && point.y < self.bottom
+        point.x >= self.left && point.y >= self.top && point.x =< self.right && point.y =< self.bottom;
     }
 }
 


### PR DESCRIPTION
### Changes:
- Added ability to reload the GUI from the tray icon and via F5 with the GUI open, this should provide an easy workaround to some weird GUI issues that happen with disconnecting monitors and other edge cases.
- Another capture will automatically be taken when the GUI is reloaded via F5 with the GUI open.
- Settings files no longer track version numbers as this system wouldn't work for migrating.

### Fixes:
- Updated bounds checks to include border
- Windows bounds with non-zero positions have been removed

