### PR TITLE
Improve windows capture

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,15 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "aho-corasick"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -722,19 +713,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "generator"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "979f00864edc7516466d6b3157706e06c032f22715700ddd878228a91d02bc56"
-dependencies = [
- "cfg-if",
- "libc",
- "log",
- "rustversion",
- "windows",
-]
-
-[[package]]
 name = "gethostname"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,7 +939,6 @@ dependencies = [
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
- "tracing-tracy",
  "tray-icon",
  "vulkan-instance",
  "vulkan-renderer",
@@ -1218,34 +1195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
 
 [[package]]
-name = "loom"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
-dependencies = [
- "cfg-if",
- "generator",
- "scoped-tls",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "malloc_buf"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "matchers"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
-dependencies = [
- "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -1857,50 +1812,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex"
-version = "1.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4219d74c6b67a3654a9fbebc4b419e22126d13d2f3c4a07ee0cb61ff79a79619"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-automata 0.4.7",
- "regex-syntax 0.8.4",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax 0.6.29",
-]
-
-[[package]]
-name = "regex-automata"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
-dependencies = [
- "aho-corasick",
- "memchr",
- "regex-syntax 0.8.4",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.6.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
-
-[[package]]
-name = "regex-syntax"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
-
-[[package]]
 name = "rustc_version"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1923,12 +1834,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "955d28af4278de8121b7ebeb796b6a45735dc01436d898801014aced2773a3d6"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1936,12 +1841,6 @@ checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
 ]
-
-[[package]]
-name = "scoped-tls"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
 
 [[package]]
 name = "scopeguard"
@@ -2241,47 +2140,12 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
- "matchers",
  "nu-ansi-term",
- "once_cell",
- "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
-]
-
-[[package]]
-name = "tracing-tracy"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be7f8874d6438e4263f9874c84eded5095bda795d9c7da6ea0192e1750d3ffe"
-dependencies = [
- "tracing-core",
- "tracing-subscriber",
- "tracy-client",
-]
-
-[[package]]
-name = "tracy-client"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63de1e1d4115534008d8fd5788b39324d6f58fc707849090533828619351d855"
-dependencies = [
- "loom",
- "once_cell",
- "tracy-client-sys",
-]
-
-[[package]]
-name = "tracy-client-sys"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98b98232a2447ce0a58f9a0bfb5f5e39647b5c597c994b63945fcccd1306fafb"
-dependencies = [
- "cc",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -944,7 +944,7 @@ dependencies = [
 
 [[package]]
 name = "hdr-snipping-tool"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
  "arboard",
  "ash",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "adler2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
+
+[[package]]
 name = "android-activity"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -52,9 +58,9 @@ dependencies = [
 
 [[package]]
 name = "arboard"
-version = "3.4.0"
+version = "3.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fb4009533e8ff8f1450a5bcbc30f4242a1d34442221f72314bea1f5dc9c7f89"
+checksum = "df099ccb16cd014ff054ac1bf392c67feeef57164b05c42f037cd40f5d4357f4"
 dependencies = [
  "clipboard-win",
  "core-graphics",
@@ -161,9 +167,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 dependencies = [
  "bytemuck_derive",
 ]
@@ -176,7 +182,7 @@ checksum = "0cc8b54b395f2fcfbb3d90c47b01c7f444d94d05bdeb775811dec868ac3bbc26"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -232,12 +238,13 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.7"
+version = "1.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
+checksum = "b62ac837cdb5cb22e10a256099b4fc502b1dfe560cb282963a974d7abd80e476"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -350,9 +357,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "core-graphics"
@@ -531,9 +538,9 @@ dependencies = [
 
 [[package]]
 name = "error-code"
-version = "3.2.0"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0474425d51df81997e2f90a21591180b38eccf27292d755f3e30750225c175b"
+checksum = "a5d9305ccc6942a704f4335694ecd3de2ea531b114ac2d51f5f843750787a92f"
 
 [[package]]
 name = "fdeflate"
@@ -556,12 +563,12 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "324a1be68054ef05ad64b861cc9eaf1d623d2d8cb25b4bf2cb9cdd902b4bf253"
 dependencies = [
  "crc32fast",
- "miniz_oxide",
+ "miniz_oxide 0.8.0",
 ]
 
 [[package]]
@@ -582,7 +589,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -631,7 +638,7 @@ checksum = "87750cf4b7a4c0625b1529e4c543c2182106e4dedc60a2a6455e00d212c489ac"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -799,7 +806,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -814,18 +821,17 @@ dependencies = [
 
 [[package]]
 name = "global-hotkey"
-version = "0.5.4"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89cb13e8c52c87e28a46eae3e5e65b8f0cd465c4c9e67b13d56c70412e792bc3"
+checksum = "d1b75248f33c73df1ed69673f6cb36d2e048ae84d29aa1d3e53199d138ebb1df"
 dependencies = [
- "bitflags 2.6.0",
- "cocoa",
  "crossbeam-channel",
  "keyboard-types",
- "objc",
+ "objc2",
+ "objc2-app-kit",
  "once_cell",
  "thiserror",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
  "x11-dl",
 ]
 
@@ -889,7 +895,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1005,9 +1011,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.3.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3fc2e30ba82dd1b3911c8de1ffc143c74a914a14e99514d7637e3099df5ea0"
+checksum = "68b900aa2f7301e21c36462b170ee99994de34dff39a4a6a528e80e7376d07e5"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1058,9 +1064,9 @@ checksum = "f5d4a7da358eff58addd2877a45865158f0d78c911d43a5784ceb7bbf52833b0"
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -1108,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.158"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "d8adc4bb1803a324070e64a98ae98f38934d91957a99cfb3a43dcbc01bc56439"
 
 [[package]]
 name = "libloading"
@@ -1229,6 +1235,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+dependencies = [
+ "adler2",
+]
+
+[[package]]
 name = "muda"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1320,7 +1335,7 @@ dependencies = [
  "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1537,9 +1552,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "33ea5043e58958ee56f3e15a90aee535795cd7dfd319846288d93c5b57d85cbe"
 
 [[package]]
 name = "option-ext"
@@ -1605,7 +1620,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.3",
+ "redox_syscall 0.5.4",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -1627,7 +1642,7 @@ checksum = "2f38a4412a78282e09a2cf38d195ea5420d15ba0602cb375210efbc877243965"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1658,14 +1673,14 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide",
+ "miniz_oxide 0.7.4",
 ]
 
 [[package]]
 name = "polling"
-version = "3.7.2"
+version = "3.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ed00ed3fbf728b5816498ecd316d1716eecaced9c0c8d2c5a6740ca214985b"
+checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -1673,7 +1688,7 @@ dependencies = [
  "pin-project-lite",
  "rustix",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1737,9 +1752,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
+checksum = "b5b9d34b8991d19d98081b46eacdd8eb58c6f2b201139f7c5f643cc155a633af"
 dependencies = [
  "proc-macro2",
 ]
@@ -1793,18 +1808,18 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+checksum = "0884ad60e090bf1345b93da0a5de8923c93884cd03f40dfcfddd3b4bee661853"
 dependencies = [
  "bitflags 2.6.0",
 ]
 
 [[package]]
 name = "redox_users"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd283d9651eeda4b2a83a43c1c91b266c40fd76ecd39a50a8c630ae69dc72891"
+checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom",
  "libredox 0.1.3",
@@ -1813,18 +1828,18 @@ dependencies = [
 
 [[package]]
 name = "rustc_version"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
 ]
 
 [[package]]
 name = "rustix"
-version = "0.38.34"
+version = "0.38.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70dc5ec042f7a43c4a73241207cecc9873a06d45debb38b329f8541d85c2730f"
+checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
@@ -1856,22 +1871,22 @@ checksum = "61697e0a1c7e512e84a621326239844a24d8207b4669b41bc18b32ea5cbf988b"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "c8e3592472072e6e22e0a54d5904d9febf8508f65fb8552499a1abc7d1078c3a"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.210"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "243902eda00fad750862fc144cea25caca5e20d615af0a81bee94ca738f1df1f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -1891,6 +1906,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simd-adler32"
@@ -1934,9 +1955,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "9f35bcdf61fd8e7be6caf75f429fdca8beb3ed76584befb503b1569faee373ed"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1979,7 +2000,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2110,7 +2131,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2169,15 +2190,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "e91b56cd4cadaeb79bbf1a5645f6b4f8dc5bde8834ad5894a8db35fda9efa1fe"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4c87d22b6e3f4a18d4d40ef354e97c90fcb14dd91d7dc0aa9d8a1172ebf7202"
+checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "valuable"
@@ -2260,34 +2281,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76bc14366121efc8dbb487ab05bcc9d346b3b5ec0eaa76e46594cabbe51762c0"
+checksum = "61e9300f63a621e96ed275155c108eb6f843b6a26d053f122ab69724559dc8ed"
 dependencies = [
  "cfg-if",
  "js-sys",
@@ -2297,9 +2319,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -2307,28 +2329,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -2432,7 +2454,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2443,7 +2465,7 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.77",
 ]
 
 [[package]]
@@ -2681,9 +2703,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winit"
-version = "0.30.4"
+version = "0.30.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4225ddd8ab67b8b59a2fee4b34889ebf13c0460c1c3fa297c58e21eb87801b33"
+checksum = "0be9e76a1f1077e04a411f0b989cbd3c93339e1771cb41e71ac4aee95bfd2c67"
 dependencies = [
  "android-activity",
  "atomic-waker",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2529,7 +2529,7 @@ dependencies = [
 
 [[package]]
 name = "windows-capture-provider"
-version = "4.0.0"
+version = "4.1.0"
 dependencies = [
  "thiserror",
  "tracing",

--- a/crates/hdr-capture/src/hdr_capture/import.rs
+++ b/crates/hdr-capture/src/hdr_capture/import.rs
@@ -64,7 +64,7 @@ impl HdrCapture {
             let mut dedicated_allocation = MemoryDedicatedAllocateInfo::default().image(image);
             let mut import_info = ImportMemoryWin32HandleInfoKHR::default()
                 .handle_type(ExternalMemoryHandleTypeFlags::OPAQUE_WIN32)
-                .handle(capture.handle.0 as isize);
+                .handle((*capture.handle).0 as isize);
 
             let allocate_info = MemoryAllocateInfo::default()
                 .allocation_size(memory_requirement.size)

--- a/crates/hdr-snipping-tool/Cargo.toml
+++ b/crates/hdr-snipping-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdr-snipping-tool"
-version = "3.2.0"
+version = "3.2.1"
 edition = "2021"
 
 build = "build.rs"

--- a/crates/hdr-snipping-tool/Cargo.toml
+++ b/crates/hdr-snipping-tool/Cargo.toml
@@ -30,8 +30,6 @@ half = { workspace = true }
 ash = { workspace = true }
 image = { workspace = true }
 
-# TODO remove tracy
-tracing-tracy = { version = "0.11", optional = true, features = ["enable"] }
 tracing-subscriber = "0.3"
 tracing-appender = "0.2"
 arboard = "3.4"

--- a/crates/hdr-snipping-tool/Cargo.toml
+++ b/crates/hdr-snipping-tool/Cargo.toml
@@ -5,9 +5,6 @@ edition = "2021"
 
 build = "build.rs"
 
-[features]
-tracy = ["tracing-tracy"]
-
 [dependencies]
 vulkan-instance = { workspace = true }
 vulkan-renderer = { workspace = true }

--- a/crates/hdr-snipping-tool/Cargo.toml
+++ b/crates/hdr-snipping-tool/Cargo.toml
@@ -35,7 +35,7 @@ chrono = { version = "0.4", features = [
 	"std",
 ], default-features = false }
 directories = "5.0"
-global-hotkey = "0.5"
+global-hotkey = "0.6"
 serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
 tray-icon = "0.14"

--- a/crates/hdr-snipping-tool/src/active_app/create_tray_icon.rs
+++ b/crates/hdr-snipping-tool/src/active_app/create_tray_icon.rs
@@ -5,7 +5,7 @@ use tray_icon::{
     BadIcon, Icon, TrayIcon, TrayIconBuilder,
 };
 
-use crate::{is_debug, IS_DEV, VERSION};
+use crate::VERSION;
 
 #[instrument(skip_all, err)]
 pub fn create_tray_icon() -> Result<TrayIcon, Error> {
@@ -16,13 +16,7 @@ pub fn create_tray_icon() -> Result<TrayIcon, Error> {
 
     let tray_menu = Menu::with_items(&[&directory_item, &quit_item])?;
 
-    let dev_tooltip = if IS_DEV { "-dev" } else { "" };
-    let debug_tooltip = if is_debug() { "-debug" } else { "" };
-
-    let tooltip = format!(
-        "HDR Snipping Tool v{}{}{}",
-        VERSION, dev_tooltip, debug_tooltip
-    );
+    let tooltip = format!("HDR Snipping Tool v{}", VERSION,);
 
     let tray_icon = TrayIconBuilder::new()
         .with_menu(Box::new(tray_menu))

--- a/crates/hdr-snipping-tool/src/active_app/mod.rs
+++ b/crates/hdr-snipping-tool/src/active_app/mod.rs
@@ -21,8 +21,8 @@ use create_tray_icon::create_tray_icon;
 use create_window::create_window;
 
 use crate::{
-    is_vk_debug,
     settings::Settings,
+    validation_enabled,
     windows_helpers::foreground_window::{get_foreground_window, set_foreground_window},
 };
 
@@ -52,7 +52,7 @@ impl ActiveApp {
         let tray_icon = create_tray_icon()?;
         tray_icon.set_visible(true)?;
 
-        let vk = Arc::new(VulkanInstance::new(&window, is_vk_debug())?);
+        let vk = Arc::new(VulkanInstance::new(&window, validation_enabled())?);
         let renderer = Renderer::new(vk.clone(), window.inner_size().into())?;
         let maximum = Maximum::new(vk.clone())?;
         let tonemap = Tonemap::new(vk.clone())?;

--- a/crates/hdr-snipping-tool/src/active_app/mod.rs
+++ b/crates/hdr-snipping-tool/src/active_app/mod.rs
@@ -36,7 +36,7 @@ pub struct ActiveApp {
     pub maximum: Maximum,
     pub tonemap: Tonemap,
 
-    pub dx: DirectXDevices,
+    pub dx: Arc<DirectXDevices>,
     pub capture_item_cache: CaptureItemCache,
 
     pub settings: Settings,
@@ -57,7 +57,7 @@ impl ActiveApp {
         let maximum = Maximum::new(vk.clone())?;
         let tonemap = Tonemap::new(vk.clone())?;
 
-        let dx = DirectXDevices::new()?;
+        let dx = Arc::new(DirectXDevices::new()?);
         let capture_item_cache = CaptureItemCache::new(&dx)?;
 
         Ok(ActiveApp {

--- a/crates/hdr-snipping-tool/src/active_capture/mod.rs
+++ b/crates/hdr-snipping-tool/src/active_capture/mod.rs
@@ -55,7 +55,9 @@ impl ActiveCapture {
         });
 
         unsafe {
-            CloseHandle(windows_capture.handle)?;
+            if !windows_capture.handle.is_invalid() {
+                CloseHandle(windows_capture.handle)?;
+            }
         }
 
         Ok(Self {

--- a/crates/hdr-snipping-tool/src/active_capture/mod.rs
+++ b/crates/hdr-snipping-tool/src/active_capture/mod.rs
@@ -40,7 +40,7 @@ impl ActiveCapture {
             None => return Err(Error::NoDisplay),
         };
 
-        let windows_capture = WindowsCapture::take_capture(&app.dx, display)?;
+        let windows_capture = WindowsCapture::take_capture(app.dx.clone(), display)?;
 
         let hdr_capture = HdrCapture::import_windows_capture(
             vk.clone(),

--- a/crates/hdr-snipping-tool/src/active_capture/mod.rs
+++ b/crates/hdr-snipping-tool/src/active_capture/mod.rs
@@ -56,7 +56,7 @@ impl ActiveCapture {
 
         unsafe {
             if !windows_capture.handle.is_invalid() {
-                CloseHandle(windows_capture.handle)?;
+                CloseHandle(*windows_capture.handle)?;
             }
         }
 

--- a/crates/hdr-snipping-tool/src/logger.rs
+++ b/crates/hdr-snipping-tool/src/logger.rs
@@ -1,51 +1,170 @@
+use chrono::Local;
 use tracing::{
     level_filters::LevelFilter,
     subscriber::{set_global_default, SetGlobalDefaultError},
+    Level,
 };
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::{fmt::format::FmtSpan, layer::SubscriberExt, Layer};
+use tracing_subscriber::{fmt::format::FmtSpan, layer::SubscriberExt};
 
 use crate::project_directory;
 
-pub fn init_tracing() -> Result<(WorkerGuard, WorkerGuard), SetGlobalDefaultError> {
+pub fn init_tracing(
+    level: LevelFilter,
+    log_span_close: bool,
+) -> Result<[WorkerGuard; 2], SetGlobalDefaultError> {
     let filter = tracing_subscriber::filter::Targets::new()
-        .with_default(LevelFilter::TRACE)
+        .with_default(level)
         .with_target("winit", LevelFilter::OFF);
 
-    // timing logger
-    let timing_filter = tracing_subscriber::filter::FilterFn::new(|metadata| {
-        metadata.level() == &LevelFilter::INFO
-    })
-    .with_max_level_hint(LevelFilter::INFO);
-    let timing_file_appender =
-        tracing_appender::rolling::never(project_directory(), "hdr-snipping-tool.timing.log");
-    let (timing_non_blocking, _timing_guard) = tracing_appender::non_blocking(timing_file_appender);
-    let timing_file_logger = tracing_subscriber::fmt::layer()
-        .with_writer(timing_non_blocking)
-        .with_span_events(FmtSpan::CLOSE)
-        .with_ansi(false)
-        .with_target(false)
-        .with_filter(timing_filter.clone());
+    // file logger
+    let file_name = file_name(level, log_span_close);
+    let file_appender = tracing_appender::rolling::never(project_directory(), file_name);
+    let (file_writer, _file_guard) = tracing_appender::non_blocking(file_appender);
 
-    // error logger
-    let file_appender =
-        tracing_appender::rolling::never(project_directory(), "hdr-snipping-tool.log");
-    let (non_blocking, _guard) = tracing_appender::non_blocking(file_appender);
-    let error_file_logger = tracing_subscriber::fmt::layer()
-        .with_writer(non_blocking)
-        .with_ansi(false)
-        .with_target(false);
-    let error_std_logger = tracing_subscriber::fmt::layer()
+    let file_logger = tracing_subscriber::fmt::layer()
+        .with_writer(file_writer)
         .with_ansi(false)
         .with_target(false);
 
+    let file_logger = if log_span_close {
+        file_logger.with_span_events(FmtSpan::CLOSE)
+    } else {
+        file_logger
+    };
+
+    // stdout logger
+    let (std_writer, _std_guard) = tracing_appender::non_blocking(std::io::stdout());
+    let std_logger = tracing_subscriber::fmt::layer()
+        .with_writer(std_writer)
+        .with_ansi(false)
+        .with_target(false);
+
+    let std_logger = if log_span_close {
+        std_logger.with_span_events(FmtSpan::CLOSE)
+    } else {
+        std_logger
+    };
+
+    // Register loggers
     let collector = tracing_subscriber::registry()
-        .with(error_file_logger)
-        .with(error_std_logger)
-        .with(timing_file_logger)
+        .with(file_logger)
+        .with(std_logger)
         .with(filter);
 
     set_global_default(collector)?;
 
-    Ok((_guard, _timing_guard))
+    Ok([_file_guard, _std_guard])
 }
+
+fn file_name(level: LevelFilter, log_span_close: bool) -> String {
+    if log_span_close {
+        if let Some(level) = level.into_level() {
+            if level == Level::DEBUG {
+                let timestamp = Local::now().format("%F_%H-%M-%S");
+                return format!("hdr-snipping-tool.timing.{}.log", timestamp);
+            }
+        }
+
+        return "hdr-snipping-tool.timing.log".to_string();
+    }
+
+    "hdr-snipping-tool.log".to_string()
+}
+
+// fn register_verbose_logger() -> Result<WorkerGuard, SetGlobalDefaultError> {}
+
+// fn register_timing_logger() -> Result<[WorkerGuard; 2], SetGlobalDefaultError> {
+//     let filter = tracing_subscriber::filter::Targets::new()
+//         .with_default(LevelFilter::DEBUG)
+//         .with_target("winit", LevelFilter::OFF);
+
+//     // let timing_filter = tracing_subscriber::filter::FilterFn::new(|metadata| {
+//     //     metadata.level() == &LevelFilter::INFO
+//     // })
+//     // .with_max_level_hint(LevelFilter::INFO);
+
+//     let file_appender =
+//         tracing_appender::rolling::never(project_directory(), "hdr-snipping-tool.timing.log");
+//     let (file_writer, _file_guard) = tracing_appender::non_blocking(file_appender);
+//     let file_logger = tracing_subscriber::fmt::layer()
+//         .with_writer(file_writer)
+//         .with_span_events(FmtSpan::CLOSE)
+//         .with_ansi(false)
+//         .with_target(false);
+//     // .with_filter(timing_filter.clone());
+
+//     let (std_writer, _std_guard) = tracing_appender::non_blocking(std::io::stdout());
+//     let std_logger = tracing_subscriber::fmt::layer()
+//         .with_writer(std_writer)
+//         .with_span_events(FmtSpan::CLOSE)
+//         .with_ansi(false)
+//         .with_target(false);
+
+//     let collector = tracing_subscriber::registry()
+//         .with(file_logger)
+//         .with(std_logger)
+//         .with(filter);
+
+//     set_global_default(collector)?;
+
+//     Ok([_file_guard, _std_guard])
+// }
+
+// fn register_debug_logger() -> Result<[WorkerGuard; 2], SetGlobalDefaultError> {
+//     let filter = tracing_subscriber::filter::Targets::new()
+//         .with_default(LevelFilter::DEBUG)
+//         .with_target("winit", LevelFilter::OFF);
+
+//     let file_appender =
+//         tracing_appender::rolling::never(project_directory(), "hdr-snipping-tool.log");
+//     let (file_writer, _file_guard) = tracing_appender::non_blocking(file_appender);
+//     let file_logger = tracing_subscriber::fmt::layer()
+//         .with_writer(file_writer)
+//         .with_ansi(false)
+//         .with_target(false);
+
+//     let (std_writer, _std_guard) = tracing_appender::non_blocking(std::io::stdout());
+//     let std_logger = tracing_subscriber::fmt::layer()
+//         .with_writer(std_writer)
+//         .with_ansi(false)
+//         .with_target(false);
+
+//     let collector = tracing_subscriber::registry()
+//         .with(file_logger)
+//         .with(std_logger)
+//         .with(filter);
+
+//     set_global_default(collector)?;
+
+//     Ok([_file_guard, _std_guard])
+// }
+
+// fn register_error_logger() -> Result<[WorkerGuard; 2], SetGlobalDefaultError> {
+//     let filter = tracing_subscriber::filter::Targets::new()
+//         .with_default(LevelFilter::INFO)
+//         .with_target("winit", LevelFilter::OFF);
+
+//     let file_appender =
+//         tracing_appender::rolling::never(project_directory(), "hdr-snipping-tool.log");
+//     let (file_writer, _file_guard) = tracing_appender::non_blocking(file_appender);
+//     let file_logger = tracing_subscriber::fmt::layer()
+//         .with_writer(file_writer)
+//         .with_ansi(false)
+//         .with_target(false);
+
+//     let (std_writer, _std_guard) = tracing_appender::non_blocking(std::io::stdout());
+//     let std_logger = tracing_subscriber::fmt::layer()
+//         .with_writer(std_writer)
+//         .with_ansi(false)
+//         .with_target(false);
+
+//     let collector = tracing_subscriber::registry()
+//         .with(file_logger)
+//         .with(std_logger)
+//         .with(filter);
+
+//     set_global_default(collector)?;
+
+//     Ok([_file_guard, _std_guard])
+// }

--- a/crates/vulkan-instance/src/buffer.rs
+++ b/crates/vulkan-instance/src/buffer.rs
@@ -8,7 +8,7 @@ use crate::{VulkanError, VulkanInstance};
 
 impl VulkanInstance {
     /// Creates a basic unbound buffer with device memory backing it.
-    #[instrument("VulkanInstance::create_unbound_buffer", skip_all, err)]
+    #[instrument("VulkanInstance::create_unbound_buffer", level = tracing::Level::DEBUG, skip_all, err)]
     pub fn create_unbound_buffer(
         &self,
         size: u64,
@@ -48,7 +48,7 @@ impl VulkanInstance {
     }
 
     /// Creates a basic bound buffer with device memory backing it.
-    #[instrument("VulkanInstance::create_bound_buffer", skip_all, err)]
+    #[instrument("VulkanInstance::create_bound_buffer", level = tracing::Level::DEBUG, skip_all, err)]
     pub fn create_bound_buffer(
         &self,
         size: u64,

--- a/crates/vulkan-instance/src/create/api_version.rs
+++ b/crates/vulkan-instance/src/create/api_version.rs
@@ -5,7 +5,7 @@ use crate::VulkanError;
 
 use super::Error;
 
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn validate_api_version(entry: &Entry) -> Result<(), Error> {
     let api_version = unsafe { entry.try_enumerate_instance_version() }
         .map_err(|e| VulkanError::VkResult(e, "enumerating instance version"))?

--- a/crates/vulkan-instance/src/create/command_buffer.rs
+++ b/crates/vulkan-instance/src/create/command_buffer.rs
@@ -8,7 +8,7 @@ use crate::VulkanError;
 
 use super::Error;
 
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn get_command_buffer(
     device: &Device,
     queue_family_index: u32,

--- a/crates/vulkan-instance/src/create/debug.rs
+++ b/crates/vulkan-instance/src/create/debug.rs
@@ -7,7 +7,7 @@ use crate::VulkanError;
 
 use super::Error;
 
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn setup_debug(
     entry: &Entry,
     instance: &Instance,

--- a/crates/vulkan-instance/src/create/instance.rs
+++ b/crates/vulkan-instance/src/create/instance.rs
@@ -27,7 +27,7 @@ const INSTANCE_EXTENSIONS: [*const ffi::c_char; 2] = [
 ];
 
 // -----
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn aquire_instance(entry: &Entry, window: &Window, debug: bool) -> Result<Instance, Error> {
     // Get extensions required to create a surface for the window
     let display_handle = window.display_handle()?;

--- a/crates/vulkan-instance/src/create/logical_device.rs
+++ b/crates/vulkan-instance/src/create/logical_device.rs
@@ -13,7 +13,7 @@ use crate::VulkanError;
 
 use super::{physical_device, Error};
 
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn get_logical_device(
     instance: &Instance,
     physical_device: PhysicalDevice,

--- a/crates/vulkan-instance/src/create/physical_device.rs
+++ b/crates/vulkan-instance/src/create/physical_device.rs
@@ -25,7 +25,7 @@ pub const REQUIRED_EXTENSIONS: [&ffi::CStr; 3] = [
 ];
 
 // -----
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn get_physical_device(
     instance: &Instance,
     surface: SurfaceKHR,

--- a/crates/vulkan-instance/src/create/surface.rs
+++ b/crates/vulkan-instance/src/create/surface.rs
@@ -9,7 +9,7 @@ use crate::VulkanError;
 
 use super::Error;
 
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn create_surface(
     entry: &Entry,
     instance: &Instance,

--- a/crates/vulkan-instance/src/memory.rs
+++ b/crates/vulkan-instance/src/memory.rs
@@ -8,7 +8,7 @@ use crate::{VulkanError, VulkanInstance};
 
 impl VulkanInstance {
     /// Writes some data to some device memory. The device memory must be host visible and coherant.
-    #[instrument("VulkanInstance::write_to_memory", skip_all, err)]
+    #[instrument("VulkanInstance::write_to_memory", level = tracing::Level::DEBUG, skip_all, err)]
     pub unsafe fn write_to_memory<T: Copy>(
         &self,
         memory: DeviceMemory,
@@ -30,7 +30,7 @@ impl VulkanInstance {
     }
 
     /// Reads some data from device memory. The device memory must be host visible and coherant.
-    #[instrument("VulkanInstance::read_from_memory", skip_all, err)]
+    #[instrument("VulkanInstance::read_from_memory", level = tracing::Level::DEBUG, skip_all, err)]
     pub unsafe fn read_from_memory<T: Copy>(
         &self,
         memory: DeviceMemory,

--- a/crates/vulkan-instance/src/shader.rs
+++ b/crates/vulkan-instance/src/shader.rs
@@ -9,7 +9,7 @@ use tracing::instrument;
 use crate::{VulkanError, VulkanInstance};
 
 impl VulkanInstance {
-    #[instrument("VulkanInstance::create_shader_module", skip_all, err)]
+    #[instrument("VulkanInstance::create_shader_module", level = tracing::Level::DEBUG, skip_all, err)]
     pub fn create_shader_module(&self, bytes: &[u8]) -> Result<ShaderModule, VulkanError> {
         let mut shader_file = Cursor::new(bytes);
         let shader_code = read_spv(&mut shader_file).map_err(VulkanError::IO)?;

--- a/crates/vulkan-renderer/src/pipelines/border.rs
+++ b/crates/vulkan-renderer/src/pipelines/border.rs
@@ -42,7 +42,7 @@ pub struct BorderPipeline {
 }
 
 impl BorderPipeline {
-    #[instrument("BorderPipeline::new", skip_all, err)]
+    #[instrument("BorderPipeline::new", level = tracing::Level::DEBUG, skip_all, err)]
     pub fn new(
         vk: Arc<VulkanInstance>,
         pipeline_rendering_create_info: PipelineRenderingCreateInfo,
@@ -106,7 +106,7 @@ impl BorderPipeline {
         })
     }
 
-    #[instrument("BorderPipeline::recreate", skip_all, err)]
+    #[instrument("BorderPipeline::recreate", level = tracing::Level::DEBUG, skip_all, err)]
     pub fn recreate(
         &mut self,
         pipeline_rendering_create_info: PipelineRenderingCreateInfo,

--- a/crates/vulkan-renderer/src/pipelines/capture.rs
+++ b/crates/vulkan-renderer/src/pipelines/capture.rs
@@ -42,7 +42,7 @@ pub struct CapturePipeline {
 }
 
 impl CapturePipeline {
-    #[instrument("CapturePipeline::new", skip_all, err)]
+    #[instrument("CapturePipeline::new", level = tracing::Level::DEBUG, skip_all, err)]
     pub fn new(
         vk: Arc<VulkanInstance>,
         pipeline_rendering_create_info: PipelineRenderingCreateInfo,
@@ -146,7 +146,7 @@ impl CapturePipeline {
         })
     }
 
-    #[instrument("CapturePipeline::recreate", skip_all, err)]
+    #[instrument("CapturePipeline::recreate", level = tracing::Level::DEBUG, skip_all, err)]
     pub fn recreate(
         &mut self,
         pipeline_rendering_create_info: PipelineRenderingCreateInfo,

--- a/crates/vulkan-renderer/src/pipelines/mod.rs
+++ b/crates/vulkan-renderer/src/pipelines/mod.rs
@@ -20,7 +20,7 @@ pub const MAIN_CSTR: &std::ffi::CStr =
     unsafe { std::ffi::CStr::from_bytes_with_nul_unchecked(b"main\0") };
 
 /// Helper function to create a basic graphics pipeline with given inputs.
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn create_pipeline(
     vk: &VulkanInstance,
     pipeline_rendering_create_info: PipelineRenderingCreateInfo,

--- a/crates/vulkan-renderer/src/pipelines/mouse_guides.rs
+++ b/crates/vulkan-renderer/src/pipelines/mouse_guides.rs
@@ -39,7 +39,7 @@ pub struct MouseGuidesPipeline {
 }
 
 impl MouseGuidesPipeline {
-    #[instrument("MouseGuidesPipeline::new", skip_all, err)]
+    #[instrument("MouseGuidesPipeline::new", level = tracing::Level::DEBUG, skip_all, err)]
     pub fn new(
         vk: Arc<VulkanInstance>,
         pipeline_rendering_create_info: PipelineRenderingCreateInfo,
@@ -103,7 +103,7 @@ impl MouseGuidesPipeline {
         })
     }
 
-    #[instrument("MouseGuidesPipeline::recreate", skip_all, err)]
+    #[instrument("MouseGuidesPipeline::recreate", level = tracing::Level::DEBUG, skip_all, err)]
     pub fn recreate(
         &mut self,
         pipeline_rendering_create_info: PipelineRenderingCreateInfo,

--- a/crates/vulkan-renderer/src/pipelines/selection_shading.rs
+++ b/crates/vulkan-renderer/src/pipelines/selection_shading.rs
@@ -41,7 +41,7 @@ pub struct SelectionShadingPipeline {
 }
 
 impl SelectionShadingPipeline {
-    #[instrument("SelectionShadingPipeline::new", skip_all, err)]
+    #[instrument("SelectionShadingPipeline::new", level = tracing::Level::DEBUG, skip_all, err)]
     pub fn new(
         vk: Arc<VulkanInstance>,
         pipeline_rendering_create_info: PipelineRenderingCreateInfo,
@@ -105,7 +105,7 @@ impl SelectionShadingPipeline {
         })
     }
 
-    #[instrument("SelectionShadingPipeline::recreate", skip_all, err)]
+    #[instrument("SelectionShadingPipeline::recreate", level = tracing::Level::DEBUG, skip_all, err)]
     pub fn recreate(
         &mut self,
         pipeline_rendering_create_info: PipelineRenderingCreateInfo,

--- a/crates/vulkan-renderer/src/pipelines/vertex_index_buffer.rs
+++ b/crates/vulkan-renderer/src/pipelines/vertex_index_buffer.rs
@@ -9,7 +9,7 @@ pub type VertexIndexBuffer = ((Buffer, DeviceMemory), (Buffer, DeviceMemory));
 
 /// Creates device local vertex and index buffers
 /// from a set of verticies and indicies.
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn create_vertex_and_index_buffer<V: Copy>(
     vk: &VulkanInstance,
     verticies: &[V],

--- a/crates/vulkan-renderer/src/swapchain.rs
+++ b/crates/vulkan-renderer/src/swapchain.rs
@@ -6,7 +6,7 @@ use ash::vk::{
     SwapchainCreateInfoKHR, SwapchainKHR, Viewport,
 };
 
-use tracing::{info, info_span, instrument};
+use tracing::{info, instrument};
 use vulkan_instance::{VulkanError, VulkanInstance};
 
 use crate::Error;
@@ -14,7 +14,7 @@ use crate::Error;
 use super::Renderer;
 
 impl Renderer {
-    #[instrument("Renderer::get_surface_format", skip_all, err)]
+    #[instrument("Renderer::get_surface_format", level = tracing::Level::DEBUG, skip_all, err)]
     pub(super) fn get_surface_format(
         vk: &VulkanInstance,
     ) -> Result<SurfaceFormatKHR, ash::vk::Result> {
@@ -116,11 +116,8 @@ impl Renderer {
             swapchain_create_info
         };
 
-        let swapchain = unsafe {
-            let _span = info_span!("create_swapchain").entered();
-            swapchain_loader.create_swapchain(&swapchain_create_info, None)
-        }
-        .map_err(|e| VulkanError::VkResult(e, "creating the swapchain"))?;
+        let swapchain = unsafe { swapchain_loader.create_swapchain(&swapchain_create_info, None) }
+            .map_err(|e| VulkanError::VkResult(e, "creating the swapchain"))?;
 
         info!("Surface format: {:#?}", surface_format.format);
         info!("Surface color space: {:#?}", surface_format.color_space);
@@ -129,7 +126,7 @@ impl Renderer {
         Ok((swapchain, surface_format))
     }
 
-    #[instrument("Renderer::transition_images", skip_all, err)]
+    #[instrument("Renderer::transition_images", level = tracing::Level::DEBUG, skip_all, err)]
     pub(super) fn transition_images(vk: &VulkanInstance, images: &[Image]) -> Result<(), Error> {
         vk.record_submit_command_buffer(vk.command_buffer, &[], &[], |device, command_buffer| {
             unsafe {
@@ -212,7 +209,7 @@ impl Renderer {
         }
     }
 
-    #[instrument("Renderer::window_size_dependant_setup", skip_all, err)]
+    #[instrument("Renderer::window_size_dependant_setup", level = tracing::Level::DEBUG, skip_all, err)]
     pub(super) fn window_size_dependant_setup(
         vk: &VulkanInstance,
         swapchain_format: SurfaceFormatKHR,

--- a/crates/windows-capture-provider/Cargo.toml
+++ b/crates/windows-capture-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-capture-provider"
-version = "4.0.0"
+version = "4.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -8,21 +8,14 @@ edition = "2021"
 [dependencies]
 thiserror = { workspace = true }
 windows = { workspace = true, features = [
-	"Foundation",
-	"Graphics_Capture",
 	"Graphics_DirectX_Direct3D11",
 	"Win32_Devices_Display",
-	"Win32_Foundation",
 	"Win32_Graphics_Direct3D_Fxc",
 	"Win32_Graphics_Direct3D11",
 	"Win32_Graphics_Dxgi_Common",
 	"Win32_Graphics_Gdi",
-	"Win32_Security",
-	"Win32_System_Threading",
 	"Win32_System_WinRT_Direct3D11",
 	"Win32_System_WinRT_Graphics_Capture",
-	"Win32_UI",
-	"Win32_UI_WindowsAndMessaging",
 ] }
 windows-core = { workspace = true }
 windows-result = { workspace = true }

--- a/crates/windows-capture-provider/src/capture_item_cache/get_displays/config_path_info.rs
+++ b/crates/windows-capture-provider/src/capture_item_cache/get_displays/config_path_info.rs
@@ -16,7 +16,7 @@ pub struct DisplayConfig {
 }
 
 /// Gets display config using the display config path infos.
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn get_display_configs() -> Result<Box<[DisplayConfig]>, Error> {
     let display_config_path_infos = get_display_config_path_infos().map_err(Error::DisplayInfos)?;
 

--- a/crates/windows-capture-provider/src/capture_item_cache/get_displays/descriptors.rs
+++ b/crates/windows-capture-provider/src/capture_item_cache/get_displays/descriptors.rs
@@ -6,7 +6,7 @@ use windows_result::Result as WindowsResult;
 use crate::DirectXDevices;
 
 /// Gets the DXGI output descriptors for the current DXGI outputs.
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn get_output_descriptors(devices: &DirectXDevices) -> WindowsResult<Box<[DXGI_OUTPUT_DESC1]>> {
     let mut output_descs = vec![];
     let mut i = 0;

--- a/crates/windows-capture-provider/src/capture_item_cache/hovered.rs
+++ b/crates/windows-capture-provider/src/capture_item_cache/hovered.rs
@@ -31,7 +31,7 @@ impl CaptureItemCache {
         info!("{}", hovered_display);
 
         // Retrieve or create capture item
-        let handle = hovered_display.handle.0 as isize;
+        let handle = (*hovered_display.handle).0 as isize;
         let capture_item = match self.capture_items.entry(handle) {
             Entry::Occupied(entry) => entry.get().clone(),
             Entry::Vacant(vacancy) => {

--- a/crates/windows-capture-provider/src/capture_item_cache/mod.rs
+++ b/crates/windows-capture-provider/src/capture_item_cache/mod.rs
@@ -34,7 +34,7 @@ impl CaptureItemCache {
                 .create_capture_item()
                 .map_err(Error::CreateCaputreItem)?;
 
-            capture_items.insert(display.handle.0 as isize, capture_item);
+            capture_items.insert((*display.handle).0 as isize, capture_item);
         }
 
         Ok(Self {

--- a/crates/windows-capture-provider/src/capture_item_cache/refresh.rs
+++ b/crates/windows-capture-provider/src/capture_item_cache/refresh.rs
@@ -16,7 +16,7 @@ impl CaptureItemCache {
         for old_handle in old_displays.iter() {
             if !current_displays
                 .iter()
-                .any(|display| display.handle.0 as isize == *old_handle)
+                .any(|display| (*display.handle).0 as isize == *old_handle)
             {
                 info!("{}: removed capture item", old_handle);
                 self.capture_items.remove(old_handle);

--- a/crates/windows-capture-provider/src/directx_devices/create_devices.rs
+++ b/crates/windows-capture-provider/src/directx_devices/create_devices.rs
@@ -17,7 +17,7 @@ use windows::{
 use windows_core::{Interface, HRESULT};
 use windows_result::{Error as WindowsError, Result as WindowsResult};
 
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn dxgi_adapter(dxgi_device: &IDXGIDevice) -> WindowsResult<IDXGIAdapter1> {
     let dxgi_adapter = unsafe { dxgi_device.GetAdapter()? };
     let dxgi_adapter_1 = dxgi_adapter.cast()?;
@@ -25,20 +25,20 @@ pub fn dxgi_adapter(dxgi_device: &IDXGIDevice) -> WindowsResult<IDXGIAdapter1> {
     Ok(dxgi_adapter_1)
 }
 
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn d3d_device(dxgi_device: &IDXGIDevice) -> WindowsResult<IDirect3DDevice> {
     let inspectable = unsafe { CreateDirect3D11DeviceFromDXGIDevice(dxgi_device)? };
     let d3d_device = inspectable.cast()?;
     Ok(d3d_device)
 }
 
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn d3d11_context(d3d11_device: &ID3D11Device) -> WindowsResult<ID3D11DeviceContext> {
     let context = unsafe { d3d11_device.GetImmediateContext()? };
     Ok(context)
 }
 
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn d3d11_device() -> WindowsResult<ID3D11Device> {
     let mut device = None;
     let mut result = d3d11_device_with_type(
@@ -64,7 +64,7 @@ pub fn d3d11_device() -> WindowsResult<ID3D11Device> {
     Ok(device)
 }
 
-#[instrument(skip_all, err)]
+#[instrument(skip_all, level = tracing::Level::DEBUG, err)]
 pub fn d3d11_device_with_type(
     driver_type: D3D_DRIVER_TYPE,
     flags: D3D11_CREATE_DEVICE_FLAG,

--- a/crates/windows-capture-provider/src/directx_devices/mod.rs
+++ b/crates/windows-capture-provider/src/directx_devices/mod.rs
@@ -3,15 +3,14 @@ mod create_devices;
 use create_devices::{d3d11_context, d3d11_device, d3d_device, dxgi_adapter};
 use thiserror::Error;
 use tracing::instrument;
-use windows::{
-    Graphics::DirectX::Direct3D11::IDirect3DDevice,
-    Win32::Graphics::{
-        Direct3D11::{ID3D11Device, ID3D11DeviceContext},
-        Dxgi::{IDXGIAdapter1, IDXGIDevice},
-    },
+use windows::Win32::Graphics::{
+    Direct3D11::{ID3D11Device, ID3D11DeviceContext},
+    Dxgi::{IDXGIAdapter1, IDXGIDevice},
 };
 use windows_core::Interface;
 use windows_result::Error as WindowsError;
+
+use crate::send_types::SendIDirect3DDevice;
 
 /// Structure containing the various directX devices used in capture aquisition.
 pub struct DirectXDevices {
@@ -19,9 +18,9 @@ pub struct DirectXDevices {
     pub dxgi_adapter: IDXGIAdapter1,
 
     /// Used to create framepool.
-    pub d3d_device: IDirect3DDevice,
+    pub d3d_device: SendIDirect3DDevice,
 
-    /// Used to retrieve capture from the GPU.
+    /// Used to create other dx contexts.
     pub d3d11_device: ID3D11Device,
 
     /// Used to retrieve capture from the GPU.
@@ -42,7 +41,7 @@ impl DirectXDevices {
 
         Ok(Self {
             dxgi_adapter,
-            d3d_device,
+            d3d_device: SendIDirect3DDevice(d3d_device),
             d3d11_device,
             d3d11_context,
         })

--- a/crates/windows-capture-provider/src/display.rs
+++ b/crates/windows-capture-provider/src/display.rs
@@ -9,12 +9,14 @@ use windows::{
 };
 use windows_result::Result as WindowsResult;
 
+use crate::SendHMONITOR;
+
 /// A windows display and related data
 #[derive(Debug, Clone, Copy)]
 #[non_exhaustive]
 pub struct Display {
     /// The display handle.
-    pub handle: HMONITOR,
+    pub handle: SendHMONITOR,
 
     /// The position of the top left corner of the display in pixels.
     /// This is relative to the top left corner of the primary display.
@@ -33,7 +35,7 @@ impl Display {
         let (position, size) = Self::position_size_from_rect(rect);
 
         Self {
-            handle,
+            handle: SendHMONITOR(handle),
             position,
             size,
             sdr_referece_white,
@@ -53,7 +55,7 @@ impl Display {
     /// Creates a graphics capture item for this display.
     pub(crate) fn create_capture_item(&self) -> WindowsResult<GraphicsCaptureItem> {
         let interop = windows::core::factory::<GraphicsCaptureItem, IGraphicsCaptureItemInterop>()?;
-        let capture_item: GraphicsCaptureItem = unsafe { interop.CreateForMonitor(self.handle)? };
+        let capture_item: GraphicsCaptureItem = unsafe { interop.CreateForMonitor(*self.handle)? };
 
         Ok(capture_item)
     }
@@ -72,7 +74,7 @@ impl Display {
 
 impl PartialEq for Display {
     fn eq(&self, other: &Self) -> bool {
-        self.handle == other.handle
+        self.handle.0 == other.handle.0
     }
 }
 

--- a/crates/windows-capture-provider/src/lib.rs
+++ b/crates/windows-capture-provider/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod capture_item_cache;
 pub mod directx_devices;
 pub mod display;
+pub mod send_types;
 pub mod windows_capture;
 
 pub use capture_item_cache::{hovered, refresh, CaptureItemCache};
 pub use directx_devices::DirectXDevices;
 pub use display::Display;
+pub use send_types::{SendHANDLE, SendHMONITOR, SendIDirect3DDevice};
 pub use windows_capture::WindowsCapture;

--- a/crates/windows-capture-provider/src/send_types/direct3d_device.rs
+++ b/crates/windows-capture-provider/src/send_types/direct3d_device.rs
@@ -1,0 +1,21 @@
+use std::ops::{Deref, DerefMut};
+
+use windows::Graphics::DirectX::Direct3D11::IDirect3DDevice;
+
+pub struct SendIDirect3DDevice(pub IDirect3DDevice);
+unsafe impl Send for SendIDirect3DDevice {}
+unsafe impl Sync for SendIDirect3DDevice {}
+
+impl Deref for SendIDirect3DDevice {
+    type Target = IDirect3DDevice;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for SendIDirect3DDevice {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/crates/windows-capture-provider/src/send_types/handle.rs
+++ b/crates/windows-capture-provider/src/send_types/handle.rs
@@ -2,6 +2,7 @@ use std::ops::{Deref, DerefMut};
 
 use windows::Win32::Foundation::HANDLE;
 
+#[derive(Debug, Clone, Copy)]
 pub struct SendHANDLE(pub HANDLE);
 
 unsafe impl Send for SendHANDLE {}

--- a/crates/windows-capture-provider/src/send_types/handle.rs
+++ b/crates/windows-capture-provider/src/send_types/handle.rs
@@ -1,0 +1,21 @@
+use std::ops::{Deref, DerefMut};
+
+use windows::Win32::Foundation::HANDLE;
+
+pub struct SendHANDLE(pub HANDLE);
+
+unsafe impl Send for SendHANDLE {}
+
+impl Deref for SendHANDLE {
+    type Target = HANDLE;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for SendHANDLE {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/crates/windows-capture-provider/src/send_types/hmonitor.rs
+++ b/crates/windows-capture-provider/src/send_types/hmonitor.rs
@@ -1,0 +1,23 @@
+use std::ops::{Deref, DerefMut};
+
+use windows::Win32::Graphics::Gdi::HMONITOR;
+
+/// Wrapper around an `HMONITOR` to make it `Send`.
+#[derive(Debug, Clone, Copy)]
+pub struct SendHMONITOR(pub HMONITOR);
+
+unsafe impl Send for SendHMONITOR {}
+
+impl Deref for SendHMONITOR {
+    type Target = HMONITOR;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for SendHMONITOR {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}

--- a/crates/windows-capture-provider/src/send_types/mod.rs
+++ b/crates/windows-capture-provider/src/send_types/mod.rs
@@ -1,0 +1,7 @@
+mod direct3d_device;
+mod handle;
+mod hmonitor;
+
+pub use direct3d_device::SendIDirect3DDevice;
+pub use handle::SendHANDLE;
+pub use hmonitor::SendHMONITOR;

--- a/crates/windows-capture-provider/src/windows_capture/mod.rs
+++ b/crates/windows-capture-provider/src/windows_capture/mod.rs
@@ -3,17 +3,16 @@ mod start_capture_session;
 pub mod take_capture;
 
 use thiserror::Error;
-use windows::Win32::Foundation::HANDLE;
 use windows_result::Error as WindowsError;
 
-use crate::display::Display;
+use crate::{display::Display, SendHANDLE};
 
 /// A capture from windows in R16G16B16A16_Float format
 #[derive(Debug)]
 #[non_exhaustive]
 pub struct WindowsCapture {
     /// Handle to the shared Dx11 texture resource.
-    pub handle: HANDLE,
+    pub handle: SendHANDLE,
 
     /// The size of the capture.
     pub size: [u32; 2],

--- a/crates/windows-capture-provider/src/windows_capture/retrieve_handle.rs
+++ b/crates/windows-capture-provider/src/windows_capture/retrieve_handle.rs
@@ -15,7 +15,7 @@ use windows_result::Error as WindowsError;
 
 /// Retrieves the capture handle from the GPU.
 #[instrument("retrieve_capture", skip_all, err)]
-pub fn retrieve_handle(d3d_capture: Direct3D11CaptureFrame) -> Result<HANDLE, WindowsError> {
+pub fn retrieve_handle(d3d_capture: &Direct3D11CaptureFrame) -> Result<HANDLE, WindowsError> {
     // Get the surface of the capture
     let surface = d3d_capture.Surface()?;
     let access: IDirect3DDxgiInterfaceAccess = surface.cast()?;

--- a/crates/windows-capture-provider/src/windows_capture/retrieve_handle.rs
+++ b/crates/windows-capture-provider/src/windows_capture/retrieve_handle.rs
@@ -1,4 +1,4 @@
-use tracing::instrument;
+use tracing::{instrument, Level};
 use windows::{
     Graphics::Capture::Direct3D11CaptureFrame,
     Win32::{
@@ -14,7 +14,7 @@ use windows_core::Interface;
 use windows_result::Error as WindowsError;
 
 /// Retrieves the capture handle from the GPU.
-#[instrument("retrieve_capture", skip_all, err)]
+#[instrument("retrieve_capture", level = Level::DEBUG, skip_all, err)]
 pub fn retrieve_handle(d3d_capture: &Direct3D11CaptureFrame) -> Result<HANDLE, WindowsError> {
     // Get the surface of the capture
     let surface = d3d_capture.Surface()?;

--- a/crates/windows-capture-provider/src/windows_capture/take_capture.rs
+++ b/crates/windows-capture-provider/src/windows_capture/take_capture.rs
@@ -34,7 +34,7 @@ impl WindowsCapture {
         });
 
         Ok(WindowsCapture {
-            handle: handle.0,
+            handle,
             size: display.size,
             display,
         })


### PR DESCRIPTION
- Wrap most Windows types in Send to allow for deferring work to other threads
- Deferred cleaning up after windows capture to a separate thread
- Retreiving capture handle moved into the frame arrived thread
- Cleanedup and improved the logging interface across the app