### PR TITLE
Allow recreation when the DXGI adapter is outdated.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1006,7 +1006,7 @@ checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 
 [[package]]
 name = "hdr-snipping-tool"
-version = "4.1.1"
+version = "4.1.2"
 dependencies = [
  "arboard",
  "ash",
@@ -2913,7 +2913,7 @@ dependencies = [
 
 [[package]]
 name = "windows-capture-provider"
-version = "6.0.1"
+version = "6.1.0"
 dependencies = [
  "thiserror 2.0.11",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -74,5 +74,6 @@ mimalloc = { version = "0.1" }
 
 "default_trait_access" = "warn"
 "clone_on_ref_ptr" = "warn"
+"todo" = "warn"
 
 "missing_safety_doc" = "allow"

--- a/crates/hdr-snipping-tool/Cargo.toml
+++ b/crates/hdr-snipping-tool/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hdr-snipping-tool"
-version = "4.1.1"
+version = "4.1.2"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true

--- a/crates/hdr-snipping-tool/src/application/capture_taker.rs
+++ b/crates/hdr-snipping-tool/src/application/capture_taker.rs
@@ -181,6 +181,18 @@ impl InnerCaptureTaker {
             );
         }
 
+        if self
+            .direct_x
+            .dxgi_adapter_outdated()
+            .report("Could not check if the DirectX devices were outdated.")
+            .unwrap_or(true)
+        {
+            self.direct_x.recreate_dxgi_adapter().report_and_panic(
+                "Could not refresh the DirectX devices.\nThe DirectX device creation failed.",
+            );
+            debug!("Recreated out-of-date DXGI device");
+        }
+
         if let Err(e) = self.cache.prune(&self.direct_x) {
             error!("Could not prune the cache: {e}");
         };
@@ -197,6 +209,19 @@ impl InnerCaptureTaker {
                 "DirectX device lost",
                 "Could not refresh the cache.\nThe DirectX device was lost.",
             );
+        }
+
+        if self
+            .direct_x
+            .dxgi_adapter_outdated()
+            .report("Could not check if the DirectX devices were outdated.")
+            .unwrap_or(true)
+        {
+            self.direct_x.recreate_dxgi_adapter().report_and_panic(
+                "Could not refresh the DirectX devices.\nThe DirectX device creation failed.",
+            );
+
+            debug!("Recreated out-of-date DXGI device");
         }
 
         // Get the monitor

--- a/crates/windows-capture-provider/Cargo.toml
+++ b/crates/windows-capture-provider/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-capture-provider"
-version = "6.0.1"
+version = "6.1.0"
 edition.workspace = true
 license.workspace = true
 authors.workspace = true


### PR DESCRIPTION
* Add function `windows_capture_provider::DirectX::dxgi_adapter_outdated`.
* Add function `windows_capture_provider::DirectX::recreate_dxgi_adapter`.
* Update `hdr_snipping_tool::InnerCaptureTaker::take_capture` and `hdr_snipping_tool::InnerCaptureTaker::refresh_cache` to check for outdated DXGI adapter then recreate if neccecary.

Should fix #59, may also fix #45.